### PR TITLE
Use Upbound build submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
+/.cache
+/.work
+/_output
+cover.out
 /bin
 /vendor
 /.vendor-new
-.vscode
-.idea
 .DS_Store
+
+# ignore IDE folders
+.vscode/
+.idea/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "build"]
+	path = build
+	url = https://github.com/upbound/build

--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,132 @@
-# Set the shell to bash always
-SHELL := /bin/bash
+# ====================================================================================
+# Setup Project
 
-# Options
-ORG_NAME=crossplane-contrib
-PROVIDER_NAME=provider-kafka
+PROJECT_NAME := provider-kafka
+PROJECT_REPO := github.com/crossplane-contrib/$(PROJECT_NAME)
 
-build: generate test
-	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o ./bin/$(PROVIDER_NAME)-controller cmd/provider/main.go
+PLATFORMS ?= linux_amd64 linux_arm64
+# -include will silently skip missing files, which allows us
+# to load those files with a target in the Makefile. If only
+# "include" was used, the make command would fail and refuse
+# to run a target until the include commands succeeded.
+-include build/makelib/common.mk
 
-image: generate test
-	docker build . -t $(ORG_NAME)/$(PROVIDER_NAME):latest -f cluster/Dockerfile
+# ====================================================================================
+# Setup Output
 
-image-push:
-	docker push $(ORG_NAME)/$(PROVIDER_NAME):latest
+-include build/makelib/output.mk
 
-run: generate
+# ====================================================================================
+# Setup Go
+
+# Set a sane default so that the nprocs calculation below is less noisy on the initial
+# loading of this file
+NPROCS ?= 1
+
+# each of our test suites starts a kube-apiserver and running many test suites in
+# parallel can lead to high CPU utilization. by default we reduce the parallelism
+# to half the number of CPU cores.
+GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
+
+GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider
+GO_LDFLAGS += -X $(GO_PROJECT)/pkg/version.Version=$(VERSION)
+GO_SUBDIRS += cmd pkg apis
+GO111MODULE = on
+-include build/makelib/golang.mk
+
+# ====================================================================================
+# Setup Kubernetes tools
+
+USE_HELM3 = true
+HELM3_VERSION = v3.6.3
+-include build/makelib/k8s_tools.mk
+
+# ====================================================================================
+# Setup Images
+
+DOCKER_REGISTRY = crossplane
+IMAGES = provider-kafka provider-kafka-controller
+-include build/makelib/image.mk
+
+# ====================================================================================
+# Targets
+
+# run `make help` to see the targets and options
+
+# We want submodules to be set up the first time `make` is run.
+# We manage the build/ folder and its Makefiles as a submodule.
+# The first time `make` is run, the includes of build/*.mk files will
+# all fail, and this target will be run. The next time, the default as defined
+# by the includes will be run instead.
+fallthrough: submodules
+	@echo Initial setup complete. Running make again . . .
+	@make
+
+# Generate a coverage report for cobertura applying exclusions on
+# - generated file
+cobertura:
+	@cat $(GO_TEST_OUTPUT)/coverage.txt | \
+		grep -v zz_generated.deepcopy | \
+		$(GOCOVER_COBERTURA) > $(GO_TEST_OUTPUT)/cobertura-coverage.xml
+
+crds.clean:
+	@$(INFO) cleaning generated CRDs
+	@find package/crds -name *.yaml -exec sed -i.sed -e '1,2d' {} \; || $(FAIL)
+	@find package/crds -name *.yaml.sed -delete || $(FAIL)
+	@$(OK) cleaned generated CRDs
+
+generate: crds.clean
+
+
+# integration tests
+e2e.run: test-integration
+
+# Run integration tests.
+test-integration: $(KIND) $(KUBECTL) $(HELM3)
+	@$(INFO) running integration tests using kind $(KIND_VERSION)
+	@$(ROOT_DIR)/cluster/local/integration_tests.sh || $(FAIL)
+	@$(OK) integration tests passed
+
+# Update the submodules, such as the common build scripts.
+submodules:
+	@git submodule sync
+	@git submodule update --init --recursive
+
+# This is for running out-of-cluster locally, and is for convenience. Running
+# this make target will print out the command which was used. For more control,
+# try running the binary directly with different arguments.
+run: go.build
+	@$(INFO) Running Crossplane locally out-of-cluster . . .
+	@# To see other arguments that can be provided, run the command with --help instead
+	$(GO_OUT_DIR)/provider --debug
+
+dev: generate
 	kubectl apply -f package/crds/ -R
 	go run cmd/provider/main.go -d
 
-all: image image-push
+manifests:
+	@$(INFO) Deprecated. Run make generate instead.
 
-generate:
-	go generate ./...
-	@find package/crds -name *.yaml -exec sed -i.sed -e '1,2d' {} \;
-	@find package/crds -name *.yaml.sed -delete
+.PHONY: cobertura submodules fallthrough test-integration run crds.clean manifests
 
-lint:
-	$(LINT) run
+# ====================================================================================
+# Special Targets
 
-tidy:
-	go mod tidy
+define CROSSPLANE_MAKE_HELP
+Crossplane Targets:
+    cobertura             Generate a coverage report for cobertura applying exclusions on generated files.
+    reviewable            Ensure a PR is ready for review.
+    submodules            Update the submodules, such as the common build scripts.
+    run                   Run crossplane locally, out-of-cluster. Useful for development.
 
-test:
-	go test -v ./...
+endef
+# The reason CROSSPLANE_MAKE_HELP is used instead of CROSSPLANE_HELP is because the crossplane
+# binary will try to use CROSSPLANE_HELP if it is set, and this is for something different.
+export CROSSPLANE_MAKE_HELP
 
-# Tools
+crossplane.help:
+	@echo "$$CROSSPLANE_MAKE_HELP"
 
-KIND=$(shell which kind)
-LINT=$(shell which golangci-lint)
+help-special: crossplane.help
 
-.PHONY: generate tidy lint clean build image all run
+.PHONY: crossplane.help help-special

--- a/cluster/images/provider-kafka-controller/Dockerfile
+++ b/cluster/images/provider-kafka-controller/Dockerfile
@@ -1,0 +1,3 @@
+FROM BASEIMAGE
+
+COPY package.yaml .

--- a/cluster/images/provider-kafka-controller/Makefile
+++ b/cluster/images/provider-kafka-controller/Makefile
@@ -1,0 +1,28 @@
+# ====================================================================================
+# Setup Project
+
+PLATFORMS := linux_amd64 linux_arm64
+include ../../../build/makelib/common.mk
+
+# ====================================================================================
+#  Options
+IMAGE = $(BUILD_REGISTRY)/provider-kafka-controller-$(ARCH)
+OSBASEIMAGE = scratch
+include ../../../build/makelib/image.mk
+
+# ====================================================================================
+# Targets
+
+img.build:
+	@$(INFO) docker build $(IMAGE)
+	@cp Dockerfile $(IMAGE_TEMP_DIR) || $(FAIL)
+	@cp -R ../../../package $(IMAGE_TEMP_DIR) || $(FAIL)
+	@cd $(IMAGE_TEMP_DIR) && $(SED_CMD) 's|BASEIMAGE|$(OSBASEIMAGE)|g' Dockerfile || $(FAIL)
+	@cd $(IMAGE_TEMP_DIR) && $(SED_CMD) 's|VERSION|$(VERSION)|g' package/crossplane.yaml || $(FAIL)
+	@cd $(IMAGE_TEMP_DIR) && find package -type f -name '*.yaml' -exec cat {} >> 'package.yaml' \; -exec printf '\n---\n' \; || $(FAIL)
+	@docker build $(BUILD_ARGS) \
+		--build-arg ARCH=$(ARCH) \
+		--build-arg TINI_VERSION=$(TINI_VERSION) \
+		-t $(IMAGE) \
+		$(IMAGE_TEMP_DIR) || $(FAIL)
+	@$(OK) docker build $(IMAGE)

--- a/cluster/images/provider-kafka/Dockerfile
+++ b/cluster/images/provider-kafka/Dockerfile
@@ -1,0 +1,3 @@
+FROM BASEIMAGE
+
+COPY package.yaml .

--- a/cluster/images/provider-kafka/Makefile
+++ b/cluster/images/provider-kafka/Makefile
@@ -1,0 +1,28 @@
+# ====================================================================================
+# Setup Project
+
+PLATFORMS := linux_amd64 linux_arm64
+include ../../../build/makelib/common.mk
+
+# ====================================================================================
+#  Options
+IMAGE = $(BUILD_REGISTRY)/provider-kafka-$(ARCH)
+OSBASEIMAGE = scratch
+include ../../../build/makelib/image.mk
+
+# ====================================================================================
+# Targets
+
+img.build:
+	@$(INFO) docker build $(IMAGE)
+	@cp Dockerfile $(IMAGE_TEMP_DIR) || $(FAIL)
+	@cp -R ../../../package $(IMAGE_TEMP_DIR) || $(FAIL)
+	@cd $(IMAGE_TEMP_DIR) && $(SED_CMD) 's|BASEIMAGE|$(OSBASEIMAGE)|g' Dockerfile || $(FAIL)
+	@cd $(IMAGE_TEMP_DIR) && $(SED_CMD) 's|VERSION|$(VERSION)|g' package/crossplane.yaml || $(FAIL)
+	@cd $(IMAGE_TEMP_DIR) && find package -type f -name '*.yaml' -exec cat {} >> 'package.yaml' \; -exec printf '\n---\n' \; || $(FAIL)
+	@docker build $(BUILD_ARGS) \
+		--build-arg ARCH=$(ARCH) \
+		--build-arg TINI_VERSION=$(TINI_VERSION) \
+		-t $(IMAGE) \
+		$(IMAGE_TEMP_DIR) || $(FAIL)
+	@$(OK) docker build $(IMAGE)

--- a/package/crds/kafka.crossplane.io_providerconfigs.yaml
+++ b/package/crds/kafka.crossplane.io_providerconfigs.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/package/crds/kafka.crossplane.io_providerconfigusages.yaml
+++ b/package/crds/kafka.crossplane.io_providerconfigusages.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/package/crds/topic.kafka.crossplane.io_topics.yaml
+++ b/package/crds/topic.kafka.crossplane.io_topics.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -1,0 +1,7 @@
+apiVersion: meta.pkg.crossplane.io/v1alpha1
+kind: Provider
+metadata:
+  name: provider-kafka
+spec:
+  controller:
+    image: DOCKER_REGISTRY/provider-kafka-controller:VERSION


### PR DESCRIPTION
This PR updates the Kafka provider to use the [Upbound Build](https://github.com/upboun/build), that is used across other Crossplane projects. 

I've tested this with:

- `make generate`
- `make run`
- `make reviewable`
- `make cobertura`


Please note that linter tests will fail unless you have applied #15.