### PR TITLE
DevTools: Kafka Env Refresh

### DIFF
--- a/devutils/devcreds.json
+++ b/devutils/devcreds.json
@@ -1,0 +1,10 @@
+{
+  "brokers":[
+    "kafka-dev-0.kafka-dev-headless:9092"
+  ],
+  "sasl":{
+    "mechanism":"PLAIN",
+    "username":"user",
+    "password":"<your-password>"
+  }
+}

--- a/devutils/devkafcliconfig
+++ b/devutils/devkafcliconfig
@@ -1,0 +1,18 @@
+current-cluster: local
+clusteroverride: ""
+clusters:
+- name: local
+  version: ""
+  brokers:
+  - kafka-dev-0.kafka-dev-headless:9092
+  SASL:
+    mechanism: PLAIN
+    username: user
+    password: <your-password>
+    clientID: ""
+    clientSecret: ""
+    tokenURL: ""
+    token: ""
+  TLS: null
+  security-protocol: ""
+  schema-registry-url: ""

--- a/devutils/devsetup.sh
+++ b/devutils/devsetup.sh
@@ -1,0 +1,16 @@
+set -x
+echo "PREREQUISITES TO INSTALL: helm, kubectl, a running kube cluster, kaf cli, crossplane, kubefwd"
+echo "See README for installation links and instructions."
+kubectl delete ns kafka-cluster;
+helm repo add bitnami https://charts.bitnami.com/bitnami;
+kubectl create ns kafka-cluster;
+helm upgrade --install kafka-dev -n kafka-cluster bitnami/kafka --set auth.clientProtocol=sasl --set deleteTopicEnable=true --set autoCreateTopicsEnable=false --wait --debug;
+CREDS=$(kubectl -n kafka-cluster exec kafka-dev-0 -- cat /opt/bitnami/kafka/config/kafka_jaas.conf | grep password | awk -F\" '{print $2}');
+sed 's/<your-password>/'"$CREDS"'/g' devcreds.json > kc.json;
+sed 's/<your-password>/'"$CREDS"'/g' devkafcliconfig > ~/.kaf/config;
+kubectl -n crossplane-system delete secret kafka-creds;
+kubectl -n crossplane-system create secret generic kafka-creds --from-file=credentials=kc.json;
+kaf config use-cluster local;
+echo "Next steps: run 'make dev' from your command line to generate your CRDS and apply them."
+echo "This will also run your provider and allow you to apply a topic."
+echo "Then run 'sudo -E kubefwd svc -n kafka-cluster' to appropriately forward your K8s traffic around."


### PR DESCRIPTION
### Description of your changes

We've created a super fast script to refresh the Kafka development environment running locally.  It deletes relevant keys and namespaces, reinstalls Kafka on Kubernetes, and sets up the passwords using generic files.

May be better applied in the Makefile, but for now it works and is efficient.

The prerequisites are having everything installed.  This does not break the process of manual installs using the README, or alter the process in any other way.

This is for development only, and won't work in other environments, nor is it intended to.  I placed them in a subdirectory devutils to prevent confusion.  Can easily be deleted and deprecated at release time.
