### PR TITLE
Replication Factor Update Error Handling. Fixes #23

### DIFF
--- a/devutils/devcreds.json
+++ b/devutils/devcreds.json
@@ -1,0 +1,10 @@
+{
+  "brokers":[
+    "kafka-dev-0.kafka-dev-headless:9092"
+  ],
+  "sasl":{
+    "mechanism":"PLAIN",
+    "username":"user",
+    "password":"<your-password>"
+  }
+}

--- a/devutils/devkafcliconfig
+++ b/devutils/devkafcliconfig
@@ -1,0 +1,18 @@
+current-cluster: local
+clusteroverride: ""
+clusters:
+- name: local
+  version: ""
+  brokers:
+  - kafka-dev-0.kafka-dev-headless:9092
+  SASL:
+    mechanism: PLAIN
+    username: user
+    password: <your-password>
+    clientID: ""
+    clientSecret: ""
+    tokenURL: ""
+    token: ""
+  TLS: null
+  security-protocol: ""
+  schema-registry-url: ""

--- a/devutils/devsetup.sh
+++ b/devutils/devsetup.sh
@@ -1,0 +1,16 @@
+set -x
+echo "PREREQUISITES TO INSTALL: helm, kubectl, a running kube cluster, kaf cli, crossplane, kubefwd"
+echo "See README for installation links and instructions."
+kubectl delete ns kafka-cluster;
+helm repo add bitnami https://charts.bitnami.com/bitnami;
+kubectl create ns kafka-cluster;
+helm upgrade --install kafka-dev -n kafka-cluster bitnami/kafka --set auth.clientProtocol=sasl --set deleteTopicEnable=true --set autoCreateTopicsEnable=false --wait --debug;
+CREDS=$(kubectl -n kafka-cluster exec kafka-dev-0 -- cat /opt/bitnami/kafka/config/kafka_jaas.conf | grep password | awk -F\" '{print $2}');
+sed 's/<your-password>/'"$CREDS"'/g' devcreds.json > kc.json;
+sed 's/<your-password>/'"$CREDS"'/g' devkafcliconfig > ~/.kaf/config;
+kubectl -n crossplane-system delete secret kafka-creds;
+kubectl -n crossplane-system create secret generic kafka-creds --from-file=credentials=kc.json;
+kaf config use-cluster local;
+echo "Next steps: run 'make dev' from your command line to generate your CRDS and apply them."
+echo "This will also run your provider and allow you to apply a topic."
+echo "Then run 'sudo -E kubefwd svc -n kafka-cluster' to appropriately forward your K8s traffic around."

--- a/internal/clients/kafka/topic/topic.go
+++ b/internal/clients/kafka/topic/topic.go
@@ -112,8 +112,12 @@ func Update(ctx context.Context, client *kadm.Client, desired *Topic) error {
 		return errors.New("topic does not exist")
 	}
 
-	if desired.Partitions != existing.Partitions || desired.ReplicationFactor != existing.ReplicationFactor {
+	if desired.Partitions != existing.Partitions {
 		return UpdatePartitions(ctx, client, desired)
+	}
+
+	if desired.ReplicationFactor != existing.ReplicationFactor {
+		return UpdateReplicationFactor()
 	}
 
 	if desired.Config != nil {
@@ -148,11 +152,13 @@ func UpdatePartitions(ctx context.Context, client *kadm.Client, desired *Topic) 
 		}
 	}
 
-	if desired.ReplicationFactor != existing.ReplicationFactor {
-		return errors.New("updating replication factor is not supported")
-	}
-
 	return nil
+}
+
+//UpdateReplicationFactor is not supported in Kafka. A user is given an error message
+func UpdateReplicationFactor() error {
+
+	return errors.New("updating replication factor is not supported")
 }
 
 // UpdateConfigs updates an optional topic Admin Configuration in Kafka

--- a/internal/clients/kafka/topic/topic.go
+++ b/internal/clients/kafka/topic/topic.go
@@ -112,7 +112,7 @@ func Update(ctx context.Context, client *kadm.Client, desired *Topic) error {
 		return errors.New("topic does not exist")
 	}
 
-	if desired.Partitions != existing.Partitions {
+	if desired.Partitions != existing.Partitions || desired.ReplicationFactor != existing.ReplicationFactor {
 		return UpdatePartitions(ctx, client, desired)
 	}
 


### PR DESCRIPTION

### Description of your changes

This PR addresses a bug where Replication Factors are attempted to be updated by a user. This is not supported functionality in Kafka, so the user needs to be thrown a meaningful error message. A new function UpdateReplicationFactor handles throwing the error to the user.

Fixes #23

I have:

- [ x] Read and followed Crossplane's [contribution process].
- [x ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested manually by applying a config with 1 replication factor and attempting to change it to three:

2022-01-19T13:51:41.617-0500    DEBUG   controller-runtime.manager.events       Warning {"object": {"kind":"Topic","name":"sample-topic","uid":"2887e9c0-6e4c-4bff-843f-196bd688edbb","apiVersion":"topic.kafka.crossplane.io/v1alpha1","resourceVersion":"886110"}, "reason": "CannotUpdateExternalResource", "message": "updating replication factor is not supported"}


