### PR TITLE
Updating spacing on comment for linter

### DIFF
--- a/internal/clients/kafka/topic/topic.go
+++ b/internal/clients/kafka/topic/topic.go
@@ -155,7 +155,7 @@ func UpdatePartitions(ctx context.Context, client *kadm.Client, desired *Topic) 
 	return nil
 }
 
-//UpdateReplicationFactor is not supported in Kafka. A user is given an error message
+// UpdateReplicationFactor is not supported in Kafka. A user is given an error message
 func UpdateReplicationFactor() error {
 
 	return errors.New("updating replication factor is not supported")


### PR DESCRIPTION
Signed-off-by: Jon Graca <jon.graca@libertymutual.com>

### Description of your changes

Missed a space for our linter in the past PR I put together for this bug fix. 

Fixes #23 

I have:

- [ x ] Read and followed Crossplane's [contribution process].
- [ x ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

No testing necessary. Minor change
