### PR TITLE
feat: adding TLS and SCRAM-SHA-512 support for AWS MSK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.18.1 // indirect
+	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/net v0.0.0-20210913180222-943fd674d43e // indirect
 	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602 // indirect

--- a/go.sum
+++ b/go.sum
@@ -638,6 +638,7 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/internal/clients/kafka/config.go
+++ b/internal/clients/kafka/config.go
@@ -14,4 +14,5 @@ type SASL struct {
 	Password  string `json:"password"`
 }
 
+// TLS is an option for enabling encryption in transit
 type TLS struct{}

--- a/internal/clients/kafka/config.go
+++ b/internal/clients/kafka/config.go
@@ -4,6 +4,7 @@ package kafka
 type Config struct {
 	Brokers []string `json:"brokers"`
 	SASL    *SASL    `json:"sasl,omitempty"`
+	TLS     *TLS     `json:"tls,omitempty"`
 }
 
 // SASL is an sasl option
@@ -12,3 +13,5 @@ type SASL struct {
 	Username  string `json:"username"`
 	Password  string `json:"password"`
 }
+
+type TLS struct{}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This PR adds support for the provider to interface with an AWS Managed Kafka (MSK) cluster, featuring:

- encrypted transport using TLS 
- SASL authentication method SCRAM-SHA-512


Quoting https://docs.aws.amazon.com/msk/latest/developerguide/msk-password.html#msk-password-limitations:

> Amazon MSK only supports SCRAM-SHA-512 authentication.



The following ProviderConfig Secret enables the features:

```
    {
      "brokers": [
        "b-1.aaa.bbb.c6.kafka.eu-central-1.amazonaws.com:9096",
        "b-2.aaa.bbb.c6.kafka.eu-central-1.amazonaws.com:9096",
        "b-3.aaa.bbb.c6.kafka.eu-central-1.amazonaws.com:9096"
      ],
      "tls": { },
      "sasl": {
        "mechanism": "scram-sha-512",
        "username": "$USERNAME",
        "password": "$PASSWORD"
      }
    }
```

Note I have not added any additional parameters to the TLS configuration block, since MSK is signed by AWS public CA which is trusted by CA bundles.

(Off topic: for mTLS support this block can be extended, but then the provider needs to be able to read k8s Secrets for the key pair as I believe we should not include the keypair in this config Secret, but use refs, to support cert-manager created keypair secrets.)

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review. <--- `client_test.go` does not yet exist, so could not add tests.

### How has this code been tested

I've used an MSK cluster with TLS and SCRAM auth enabled. The provider works.

[contribution process]: https://git.io/fj2m9
