### PR TITLE
feat: add mtls support resolves #37

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/twmb/franz-go/pkg/kadm v0.0.0-20211102021212-9a7f9860bbb6
 	github.com/twmb/franz-go/pkg/kmsg v0.0.0-20211104051938-70808186d5f7
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+	k8s.io/api v0.21.3
 	k8s.io/apimachinery v0.21.3
 	k8s.io/client-go v0.21.3
 	sigs.k8s.io/controller-runtime v0.9.6
@@ -74,7 +75,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	k8s.io/api v0.21.3 // indirect
 	k8s.io/apiextensions-apiserver v0.21.3 // indirect
 	k8s.io/component-base v0.21.3 // indirect
 	k8s.io/klog/v2 v2.8.0 // indirect

--- a/internal/clients/kafka/client.go
+++ b/internal/clients/kafka/client.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"os"
@@ -12,14 +13,27 @@ import (
 	"github.com/twmb/franz-go/pkg/sasl"
 	"github.com/twmb/franz-go/pkg/sasl/plain"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// default Secret field names for TLS certificates, like managed by cert-manager
+	defaultClientCertificateKeyField  = "tls.key"
+	defaultClientCertificateCertField = "tls.crt"
+
+	errCannotParse                    = "cannot parse credentials"
+	errMissingClientCertSecretRefKeys = "missing client cert ref secret name or namespace"
+	errCannotReadClientCertSecret     = "cannot read client cert secret"
 )
 
 // NewAdminClient creates a new AdminClient with supplied credentials
-func NewAdminClient(data []byte) (*kadm.Client, error) {
+func NewAdminClient(ctx context.Context, data []byte, kube client.Client) (*kadm.Client, error) {
 	kc := Config{}
 
 	if err := json.Unmarshal(data, &kc); err != nil {
-		return nil, errors.Wrap(err, "cannot parse credentials")
+		return nil, errors.Wrap(err, errCannotParse)
 	}
 
 	opts := []kgo.Opt{
@@ -48,6 +62,25 @@ func NewAdminClient(data []byte) (*kadm.Client, error) {
 
 	if kc.TLS != nil {
 		tc := new(tls.Config)
+		tc.InsecureSkipVerify = kc.TLS.InsecureSkipVerify
+
+		if sr := kc.TLS.ClientCertificateSecretRef; sr != nil {
+			if sr.Name == "" || sr.Namespace == "" {
+				return nil, errors.New(errMissingClientCertSecretRefKeys)
+			}
+			secret := &corev1.Secret{}
+			if err := kube.Get(ctx, types.NamespacedName{Namespace: sr.Namespace, Name: sr.Name}, secret); err != nil {
+				return nil, errors.Wrap(err, errCannotReadClientCertSecret)
+			}
+			kf := valueOrDefault(sr.KeyField, defaultClientCertificateKeyField)
+			cf := valueOrDefault(sr.CertField, defaultClientCertificateCertField)
+			kp, err := tls.X509KeyPair(secret.Data[cf], secret.Data[kf])
+			if err != nil {
+				return nil, errors.Wrapf(err, "Invalid key pair, using fields %q/%q from secret %q in namespace %q",
+					cf, kf, sr.Name, sr.Namespace)
+			}
+			tc.Certificates = append(tc.Certificates, kp)
+		}
 		opts = append(opts, kgo.DialTLSConfig(tc))
 	}
 
@@ -56,4 +89,12 @@ func NewAdminClient(data []byte) (*kadm.Client, error) {
 		return nil, err
 	}
 	return kadm.NewClient(c), nil
+}
+
+// Helper method to return default if value string is empty.
+func valueOrDefault(value, defaultValue string) string {
+	if value != "" {
+		return value
+	}
+	return defaultValue
 }

--- a/internal/clients/kafka/config.go
+++ b/internal/clients/kafka/config.go
@@ -20,7 +20,7 @@ type TLS struct {
 	InsecureSkipVerify         bool                        `json:"insecureSkipVerify"`
 }
 
-// ClientCertificate is a TLS option for enable mTLS
+// ClientCertificateSecretRef is a TLS option for enable mTLS
 type ClientCertificateSecretRef struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`

--- a/internal/clients/kafka/config.go
+++ b/internal/clients/kafka/config.go
@@ -15,4 +15,15 @@ type SASL struct {
 }
 
 // TLS is an option for enabling encryption in transit
-type TLS struct{}
+type TLS struct {
+	ClientCertificateSecretRef *ClientCertificateSecretRef `json:"clientCertificateSecretRef,omitempty"`
+	InsecureSkipVerify         bool                        `json:"insecureSkipVerify"`
+}
+
+// ClientCertificate is a TLS option for enable mTLS
+type ClientCertificateSecretRef struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	KeyField  string `json:"keyField,omitempty"`
+	CertField string `json:"certField,omitempty"`
+}

--- a/internal/clients/kafka/topic/topic_test.go
+++ b/internal/clients/kafka/topic/topic_test.go
@@ -28,7 +28,7 @@ var dataTesting = []byte(
 
 func TestCreate(t *testing.T) {
 
-	newAc, _ := kafka.NewAdminClient(dataTesting)
+	newAc, _ := kafka.NewAdminClient(context.Background(), dataTesting, nil)
 
 	type args struct {
 		ctx    context.Context
@@ -101,7 +101,7 @@ func TestCreate(t *testing.T) {
 
 func TestGet(t *testing.T) {
 
-	newAc, _ := kafka.NewAdminClient(dataTesting)
+	newAc, _ := kafka.NewAdminClient(context.Background(), dataTesting, nil)
 
 	type args struct {
 		ctx    context.Context
@@ -263,7 +263,7 @@ func TestIsUpToDate(t *testing.T) {
 
 func TestCreateDuplicateTopic(t *testing.T) {
 
-	newAc, _ := kafka.NewAdminClient(dataTesting)
+	newAc, _ := kafka.NewAdminClient(context.Background(), dataTesting, nil)
 
 	fmt.Printf("------Checking duplicate topic creation logic------")
 
@@ -350,7 +350,7 @@ func TestCreateDuplicateTopic(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 
-	newAc, _ := kafka.NewAdminClient(dataTesting)
+	newAc, _ := kafka.NewAdminClient(context.Background(), dataTesting, nil)
 
 	type args struct {
 		ctx    context.Context

--- a/internal/controller/acl/acl.go
+++ b/internal/controller/acl/acl.go
@@ -87,7 +87,7 @@ type connector struct {
 	kube         client.Client
 	usage        resource.Tracker
 	log          logging.Logger
-	newServiceFn func(creds []byte) (*kadm.Client, error)
+	newServiceFn func(ctx context.Context, creds []byte, kube client.Client) (*kadm.Client, error)
 }
 
 // Connect typically produces an ExternalClient by:
@@ -116,7 +116,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errGetCreds)
 	}
 
-	svc, err := c.newServiceFn(data)
+	svc, err := c.newServiceFn(ctx, data, c.kube)
 	if err != nil {
 		return nil, errors.Wrap(err, errNewClient)
 	}

--- a/internal/controller/topic/topic.go
+++ b/internal/controller/topic/topic.go
@@ -80,7 +80,7 @@ type connector struct {
 	kube         client.Client
 	usage        resource.Tracker
 	log          logging.Logger
-	newServiceFn func(creds []byte) (*kadm.Client, error)
+	newServiceFn func(ctx context.Context, creds []byte, kube client.Client) (*kadm.Client, error)
 }
 
 // Connect typically produces an ExternalClient by:
@@ -109,7 +109,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errGetCreds)
 	}
 
-	svc, err := c.newServiceFn(data)
+	svc, err := c.newServiceFn(ctx, data, c.kube)
 	if err != nil {
 		return nil, errors.Wrap(err, errNewClient)
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

My stab at adding mTLS support, re https://github.com/crossplane-contrib/provider-kafka/issues/37

Tested with AWS MSK, using this ProviderConfig credential Secret:

```
{
  "brokers": [
    "b-1.redacted.kafka.eu-central-1.amazonaws.com:9094",
    "b-2.redacted.kafka.eu-central-1.amazonaws.com:9094",
    "b-3.redacted.kafka.eu-central-1.amazonaws.com:9094"
  ],
  "tls": {
    "clientCertificateSecretRef": {
      "name": "my-client-cert",
      "namespace": "some-ns"
    }
  }
}
```

Where `clientCertificateSecretRef` references a TLS Secret by name and namespace. The Secret keys used match the TLS definition, as used by cert-manager.


I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

- Test on AWS MSK with AWS Private CA linked
- Client certificate requested via cert-manager, signed by AWS Private CA using https://github.com/cert-manager/aws-privateca-issuer
- ProviderConfig credential Secret as described above with ref to the client cert Secret.

[contribution process]: https://git.io/fj2m9
