### PR TITLE
PROVIDER-KAFKA 46: Topic controller Observe function doesn't distingu…

### DIFF
--- a/internal/clients/kafka/topic/topic.go
+++ b/internal/clients/kafka/topic/topic.go
@@ -30,7 +30,7 @@ const (
 	errNoDeleteResponseForTopic   = "no delete response for topic"
 	errCannotDeleteTopic          = "cannot delete topic"
 	errCannotGetTopic             = "cannot get topic"
-	errTopicDoesNotExist          = "topic does not exist"
+	ErrTopicDoesNotExist          = "topic does not exist"
 	errCannotUpdateTopicConfigs   = "cannot update topic configs"
 )
 
@@ -42,7 +42,7 @@ func Get(ctx context.Context, client *kadm.Client, name string) (*Topic, error) 
 		return nil, errors.Wrap(err, errCannotListTopics)
 	}
 	if td[name].Err != nil {
-		return nil, errors.Wrap(td[name].Err, errTopicDoesNotExist)
+		return nil, errors.Wrap(td[name].Err, ErrTopicDoesNotExist)
 	}
 
 	t, ok := td[name]
@@ -124,7 +124,7 @@ func Update(ctx context.Context, client *kadm.Client, desired *Topic) error {
 		return errors.Wrap(err, errCannotGetTopic)
 	}
 	if existing == nil {
-		return errors.New(errTopicDoesNotExist)
+		return errors.New(ErrTopicDoesNotExist)
 	}
 
 	if desired.Partitions != existing.Partitions {
@@ -150,7 +150,7 @@ func UpdatePartitions(ctx context.Context, client *kadm.Client, desired *Topic) 
 		return errors.Wrap(err, errCannotGetTopic)
 	}
 	if existing == nil {
-		return errors.New(errTopicDoesNotExist)
+		return errors.New(ErrTopicDoesNotExist)
 	}
 
 	if desired.Partitions != existing.Partitions {


### PR DESCRIPTION
…ish between non-existing topics and errors from the client in retrieving the topic

* Exposed error code `ErrTopicDoesNotExist` in client
* Added small check to return different ExternalObservation depending on the error

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
