### PR TITLE
Update workflow to set go version to 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
           kubectl create ns kafka-cluster
           helm upgrade --install kafka-dev -n kafka-cluster bitnami/kafka \
-            --version 15.0.1 \
+            --version 20.0.5 \
             --set auth.clientProtocol=sasl \
             --set deleteTopicEnable=true \
             --set authorizerClassName="kafka.security.authorizer.AclAuthorizer" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,6 @@ jobs:
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-pkg-
 
-      - name: Vendor Dependencies
-        run: make vendor vendor.check
-
       # Go version coming with golangci-lint-action may not be our desired
       # go version. We deploy our desired go version and then skip go
       # installation in golangci-lint-action in the next step as suggested
@@ -80,6 +77,10 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
+
+      - name: Vendor Dependencies
+        run: make vendor vendor.check
+
       # We could run 'make lint' to ensure our desired Go version, but we
       # prefer this action because it leaves 'annotations' (i.e. it comments
       # on PRs to point out linter violations).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.17'
+  GO_VERSION: '1.19'
   GOLANGCI_VERSION: 'v1.47.1'
   DOCKER_BUILDX_VERSION: 'v0.4.2'
   KIND_VERSION: 'v0.12.0'


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I bumped the GO_VERSION env var in the GitHub workflow to 1.19. It's the only remaining reference to 1.17 I found.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I can't directly test the workflow (or can I?), but I ran the failing `make vendor vendor.check` step using both golang 1.17 and 1.19. I repro the failing step with 1.17, and it works with 1.19. Makes sense. Hopefully the failures don't run deeper. 

