### PR TITLE
Update acl controller to cache the client

### DIFF
--- a/internal/controller/acl/acl.go
+++ b/internal/controller/acl/acl.go
@@ -68,6 +68,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger) error {
 		managed.WithExternalConnectDisconnecter(&connectDisconnector{
 			kube:         mgr.GetClient(),
 			usage:        resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
+			log:          l,
 			newServiceFn: kafka.NewAdminClient}),
 		managed.WithLogger(l.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
@@ -120,6 +121,7 @@ func (c *connectDisconnector) Connect(ctx context.Context, mg resource.Managed) 
 	if err != nil {
 		return nil, errors.Wrap(err, errNewClient)
 	}
+	c.cachedClient = svc
 
 	return &external{kafkaClient: svc, log: c.log}, nil
 }


### PR DESCRIPTION
### Description of your changes

This is a follow-up to #50. I mistakenly left out the change in the ACL controller where we store the client, meaning that while the `Disconnect` method is called, there isn't anything available to actually disconnect. Whoops!

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I deployed it into a test cluster and have verified that the goroutine count remains steady instead of linearly increasing