### PR TITLE
Fix ACL deletion

### DIFF
--- a/internal/clients/kafka/acl/acl.go
+++ b/internal/clients/kafka/acl/acl.go
@@ -122,7 +122,20 @@ func Delete(ctx context.Context, cl *kadm.Client, accessControlList *AccessContr
 	rpt, _ := kmsg.ParseACLResourcePatternType(strings.ToLower(accessControlList.ResourcePatternTypeFilter))
 
 	b := kadm.ACLBuilder{}
-	ab := b.Topics(accessControlList.ResourceName).Allow(accessControlList.ResourcePrincipal).AllowHosts(accessControlList.ResourceHost).Operations(ao[0]).ResourcePatternType(rpt)
+	ab := b.Allow(accessControlList.ResourcePrincipal).AllowHosts(accessControlList.ResourceHost).Operations(ao[0]).ResourcePatternType(rpt)
+
+	switch accessControlList.ResourceType {
+	case "Topic":
+		ab = ab.Topics(accessControlList.ResourceName)
+	case "Group":
+		ab = ab.Groups(accessControlList.ResourceName)
+	case "TransactionalID":
+		ab = ab.TransactionalIDs(accessControlList.ResourceName)
+	case "Cluster":
+		ab = ab.Clusters()
+	case "Any":
+		ab = ab.AnyResource(accessControlList.ResourceName)
+	}
 
 	resp, err := cl.DeleteACLs(ctx, ab)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This is a fix for removing the ACLs created not only for Topic.
Prior to this, all ACLs created for resources other than Topic could not be deleted correctly from Kubernetes

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
I deployed it into a test cluster and have verified that the ACLs for Cluster, Group, TransactionalID can be successfully deleted from Kubernetes and Kafka
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
