### PR TITLE
chore: update OWNERS.md file with new maintainer team

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,14 +1,16 @@
 # OWNERS
 
-This page lists all maintainers for **this** repository. Each repository in the [Crossplane
-organization](https://github.com/crossplane/) will list their repository maintainers in their own
-`OWNERS.md` file.
-
-Please see the Crossplane
-[GOVERNANCE.md](https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md) for governance
-guidelines and responsibilities for the steering committee and maintainers.
+This page lists all maintainers for **this** repository. Each repository in the
+[Crossplane Contrib organization](https://github.com/crossplane-contrib/) will list their
+repository maintainers in their own `OWNERS.md` file.
 
 ## Maintainers
+
+* Erik Godding Boye ([erikgb](https://github.com/erikgb))
+* J. Fernández ([fernandezcuesta](https://github.com/fernandezcuesta))
+* Pascal Arevalo ([pascaruchan](https://github.com/pascaruchan))
+
+## Emeritus Maintainers
 
 * Nic Cope <negz@upbound.io> ([negz](https://github.com/negz))
 * Daniel Mangum <dan@upbound.io> ([hasheddan](https://github.com/hasheddan))


### PR DESCRIPTION
### Description of your changes

This PR updates the OWNERS.md file with the new maintainer team proposed in #76.

The current maintainer team has been moved to emeritus status as they are no longer active.

@erikgb and @fernandezcuesta have been added to the maintainer team and hope to start bringing this provider into compliance with the community extension project policies discussed in #76. 

Thank you for the investment in this project folks! 🙇‍♂️ 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `make reviewable test` to ensure this PR is ready for review.~

[contribution process]: https://git.io/fj2m9
