### PR TITLE
Address multiple correctness and performance issues in kafka client

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,10 @@
 ---
 name: Bug Report
-about: Help us diagnose and fix bugs in Crossplane
+about: Help us diagnose and fix bugs in provider-kafka
 labels: bug
 ---
 <!--
-Thank you for helping to improve Crossplane!
+Thank you for helping to improve provider-kafka!
 
 Please be sure to search for open issues before raising a new one. We use issues
 for bug reports and feature requests. Please find us at https://slack.crossplane.io
@@ -13,7 +13,7 @@ for questions, support, and discussion.
 
 ### What happened?
 <!--
-Please let us know what behaviour you expected and how Crossplane diverged from
+Please let us know what behaviour you expected and how it diverged from
 that behaviour.
 -->
 
@@ -26,10 +26,10 @@ appreciated!
 -->
 
 ### What environment did it happen in?
-Crossplane version: 
+provider-kafka version: 
 
 <!--
-Include at least the version or commit of Crossplane you were running. Consider
+Include at least the version or commit of provider-kafka you were running. Consider
 also including your:
 
 * Cloud provider or hardware configuration

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,10 @@
 ---
 name: Feature Request
-about: Help us make Crossplane more useful
+about: Help us make provider-kafka more useful
 labels: enhancement
 ---
 <!--
-Thank you for helping to improve Crossplane!
+Thank you for helping to improve provider-kafka!
 
 Please be sure to search for open issues before raising a new one. We use issues
 for bug reports and feature requests. Please find us at https://slack.crossplane.io
@@ -18,7 +18,7 @@ Leading with this context helps frame the feature request so we can ensure we
 implement it sensibly.
 --->
 
-### How could Crossplane help solve your problem?
+### How could provider-kafka help solve your problem?
 <!--
-Let us know how you think Crossplane could help with your use case. 
+Let us know how you think provider-kafka could help with your use case. 
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
 <!--
-Thank you for helping to improve Crossplane!
+Thank you for helping to improve provider-kafka!
 
-Please read through https://git.io/fj2m9 if this is your first time opening a
-Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
-you need any help contributing.
+Please read through Crossplane's [contribution process] if this is your
+first time opening a provider-kafka pull request.
+Find us in https://slack.crossplane.io/ if you need any help contributing.
 -->
 
 ### Description of your changes
@@ -12,7 +12,7 @@ you need any help contributing.
 Briefly describe what this pull request does. Be sure to direct your reviewers'
 attention to anything that needs special consideration.
 
-We love pull requests that resolve an open Crossplane issue. If yours does, you
+We love pull requests that resolve an open provider-kafka issue. If yours does, you
 can uncomment the below line to indicate which issue your PR fixes, for example
 "Fixes #500":
 

--- a/internal/clients/kafka/acl/acl.go
+++ b/internal/clients/kafka/acl/acl.go
@@ -66,9 +66,9 @@ func List(ctx context.Context, cl *kadm.Client, accessControlList *AccessControl
 
 	resp, err := cl.DescribeACLs(ctx, ab)
 	if err != nil {
-		return nil, fmt.Errorf("describe ACLs response is empty: %w", err)
+		return nil, fmt.Errorf("describe ACLs failed: %w", err)
 	}
-	if exists := resp[0].Described; len(exists) == 0 {
+	if len(resp) == 0 || len(resp[0].Described) == 0 {
 		return nil, nil
 	}
 
@@ -94,11 +94,8 @@ func Create(ctx context.Context, cl *kadm.Client, accessControlList *AccessContr
 	if err != nil {
 		return err
 	}
-	if resp != nil {
-		a := resp[0].Principal
-		if len(a) == 0 {
-			return errors.New("no create response for acl")
-		}
+	if len(resp) == 0 || len(resp[0].Principal) == 0 {
+		return errors.New("no create response for acl")
 	}
 
 	return nil

--- a/internal/clients/kafka/client.go
+++ b/internal/clients/kafka/client.go
@@ -34,6 +34,10 @@ func NewAdminClient(ctx context.Context, data []byte, kube client.Client) (*kadm
 		return nil, fmt.Errorf("%s: %w", errCannotParse, err)
 	}
 
+	if len(kc.Brokers) == 0 {
+		return nil, errors.New(errMissingBrokers)
+	}
+
 	// Validate TLS configuration if provided
 	if kc.TLS != nil && kc.TLS.DialTimeoutSeconds < 0 {
 		return nil, fmt.Errorf("%s (received: %d)", errInvalidDialTimeout, kc.TLS.DialTimeoutSeconds)
@@ -250,17 +254,8 @@ func newAwsMskIamMechanism(ctx context.Context, saslCfg *SASL) (sasl.Mechanism, 
 	}), nil
 }
 
-// validateClientCertificatePath checks that cert and key files exist on disk and form a valid pair.
+// validateClientCertificatePath checks that cert and key files can be read and form a valid pair.
 func validateClientCertificatePath(fr *ClientCertificatePath) error {
-	// Validate that files exist and can be read initially
-	if _, err := os.Stat(fr.CertFile); err != nil {
-		return fmt.Errorf("%s %q: %w", errCannotReadClientCertFile, fr.CertFile, err)
-	}
-	if _, err := os.Stat(fr.KeyFile); err != nil {
-		return fmt.Errorf("%s %q: %w", errCannotReadClientCertFile, fr.KeyFile, err)
-	}
-
-	// Validate that cert and key form a valid pair
 	certPEM, err := os.ReadFile(fr.CertFile)
 	if err != nil {
 		return fmt.Errorf("%s %q: %w", errCannotReadClientCertFile, fr.CertFile, err)

--- a/internal/clients/kafka/client_test.go
+++ b/internal/clients/kafka/client_test.go
@@ -115,12 +115,8 @@ func TestNewAdminClient_NegativeDialTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	brokersFromDataTesting, err := json.Marshal(credentials.Brokers)
-	if err != nil {
-		t.Fatalf("failed to marshal brokers: %v", err)
-	}
 	data := []byte(`{
-		"brokers": ` + string(brokersFromDataTesting) + `,
+		"brokers": ["localhost:9092"],
 		"tls": {
 			"dialTimeoutSeconds": -5
 		}

--- a/internal/clients/kafka/constants.go
+++ b/internal/clients/kafka/constants.go
@@ -34,6 +34,7 @@ const (
 	tlsVersion12 = "TLS12"
 	tlsVersion13 = "TLS13"
 
+	errMissingBrokers                 = "at least one broker address is required"
 	errCannotAppendCACert             = "cannot append CA certificate to pool"
 	errCannotParse                    = "cannot parse credentials"
 	errCannotReadCACertFile           = "cannot read CA cert file"

--- a/internal/clients/kafka/topic/topic.go
+++ b/internal/clients/kafka/topic/topic.go
@@ -43,13 +43,9 @@ func Get(ctx context.Context, client *kadm.Client, name string) (*Topic, error) 
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", errCannotListTopics, err)
 	}
-	if td[name].Err != nil {
-		return nil, fmt.Errorf("%s: %w", ErrTopicDoesNotExist, td[name].Err)
-	}
-
-	t, ok := td[name]
-	if !ok {
-		return nil, errors.New(errNoCreateResponse)
+	t := td[name]
+	if t.Err != nil {
+		return nil, fmt.Errorf("%s: %w", ErrTopicDoesNotExist, t.Err)
 	}
 
 	tc, err := client.DescribeTopicConfigs(ctx, name)
@@ -117,7 +113,6 @@ func Delete(ctx context.Context, client *kadm.Client, name string) error {
 
 // Update determines if a Topic Partition or a Topic Admin Config update needs to be called and routes properly
 func Update(ctx context.Context, client *kadm.Client, desired *Topic) error {
-	// First Get existing Topic
 	existing, err := Get(ctx, client, desired.Name)
 	if err != nil {
 		return fmt.Errorf("%s: %w", errCannotGetTopic, err)
@@ -127,7 +122,7 @@ func Update(ctx context.Context, client *kadm.Client, desired *Topic) error {
 	}
 
 	if desired.Partitions != existing.Partitions {
-		return UpdatePartitions(ctx, client, desired)
+		return updatePartitions(ctx, client, desired, existing)
 	}
 
 	if desired.ReplicationFactor != existing.ReplicationFactor {
@@ -135,41 +130,29 @@ func Update(ctx context.Context, client *kadm.Client, desired *Topic) error {
 	}
 
 	if desired.Config != nil {
-		return UpdateConfigs(ctx, client, desired)
+		return updateConfigs(ctx, client, desired, existing)
 	}
 
 	return nil
 }
 
-// UpdatePartitions updates a topic Partition count in Kafka
-func UpdatePartitions(ctx context.Context, client *kadm.Client, desired *Topic) error {
-	// First Get existing Topic
-	existing, err := Get(ctx, client, desired.Name)
+// updatePartitions updates a topic Partition count in Kafka, reusing the already-fetched existing topic.
+func updatePartitions(ctx context.Context, client *kadm.Client, desired *Topic, existing *Topic) error {
+	if desired.Partitions < existing.Partitions {
+		return fmt.Errorf("cannot decrease topic partitions from %d to %d: Kafka does not support reducing the number of partitions",
+			existing.Partitions, desired.Partitions)
+	}
+	resp, err := client.UpdatePartitions(ctx, int(desired.Partitions), desired.Name)
 	if err != nil {
-		return fmt.Errorf("%s: %w", errCannotGetTopic, err)
+		return fmt.Errorf("cannot update topic partitions: %w", err)
 	}
-	if existing == nil {
-		return errors.New(ErrTopicDoesNotExist)
+	r, err := resp.On(desired.Name, nil)
+	if err != nil {
+		return fmt.Errorf("cannot find topic in update partitions result: %w", err)
 	}
-
-	if desired.Partitions != existing.Partitions {
-		if desired.Partitions < existing.Partitions {
-			return fmt.Errorf("cannot decrease topic partitions from %d to %d: Kafka does not support reducing the number of partitions",
-				existing.Partitions, desired.Partitions)
-		}
-		resp, err := client.UpdatePartitions(ctx, int(desired.Partitions), desired.Name)
-		if err != nil {
-			return fmt.Errorf("cannot update topic partitions: %w", err)
-		}
-		r, err := resp.On(desired.Name, nil)
-		if err != nil {
-			return fmt.Errorf("cannot find topic in update partitions result: %w", err)
-		}
-		if r.Err != nil {
-			return fmt.Errorf("error in update partitions result: %w", r.Err)
-		}
+	if r.Err != nil {
+		return fmt.Errorf("error in update partitions result: %w", r.Err)
 	}
-
 	return nil
 }
 
@@ -178,40 +161,28 @@ func UpdateReplicationFactor() error {
 	return errors.New("updating replication factor is not supported")
 }
 
-// UpdateConfigs updates an optional topic Admin Configuration in Kafka
-func UpdateConfigs(ctx context.Context, client *kadm.Client, desired *Topic) error {
-	// First Get existing Topic
-	existing, err := Get(ctx, client, desired.Name)
-	if err != nil {
-		return fmt.Errorf("%s: %w", errCannotGetTopic, err)
-	}
-	if existing == nil {
-		return errors.New(ErrTopicDoesNotExist)
-	}
-
-	if desired.Config != nil {
-		configs := desired.Config
-		existingConfig := existing.Config
-
-		for key, value := range configs {
-			ev := existingConfig[key]
-			if stringValue(value) != stringValue(ev) {
-				s := kadm.AlterConfig{
-					Op:    kadm.SetConfig, // Op is the incremental alter operation to perform.
-					Name:  key,            // Name is the name of the config to alter.
-					Value: value,          // Value is the value to use when altering, if any.
-				}
-				r, err := client.AlterTopicConfigs(ctx, []kadm.AlterConfig{s}, desired.Name)
-				if err != nil {
-					return fmt.Errorf("%s: %w", errCannotUpdateTopicConfigs, err)
-				}
-				if r[0].Err != nil {
-					return fmt.Errorf("%s: %w", errCannotUpdateTopicConfigs, r[0].Err)
-				}
-			}
+// updateConfigs updates topic config keys that differ, batching all changes into a single Kafka call.
+func updateConfigs(ctx context.Context, client *kadm.Client, desired *Topic, existing *Topic) error {
+	var changes []kadm.AlterConfig
+	for key, value := range desired.Config {
+		if stringValue(value) != stringValue(existing.Config[key]) {
+			changes = append(changes, kadm.AlterConfig{
+				Op:    kadm.SetConfig,
+				Name:  key,
+				Value: value,
+			})
 		}
 	}
-
+	if len(changes) == 0 {
+		return nil
+	}
+	r, err := client.AlterTopicConfigs(ctx, changes, desired.Name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", errCannotUpdateTopicConfigs, err)
+	}
+	if len(r) > 0 && r[0].Err != nil {
+		return fmt.Errorf("%s: %w", errCannotUpdateTopicConfigs, r[0].Err)
+	}
 	return nil
 }
 

--- a/internal/controller/cluster/acl/acl.go
+++ b/internal/controller/cluster/acl/acl.go
@@ -59,6 +59,7 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 
 	opts := []managed.ReconcilerOption{
 		managed.WithExternalConnector(&connector{
+			cache:        &kafka.ClientCache{},
 			kube:         mgr.GetClient(),
 			usage:        resource.NewLegacyProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 			newServiceFn: kafka.NewAdminClient,
@@ -112,7 +113,7 @@ func SetupGated(mgr ctrl.Manager, o controller.Options) error {
 
 // A connector is expected to produce an ExternalClient when its Connect method is called.
 type connector struct {
-	cache        kafka.ClientCache
+	cache        *kafka.ClientCache
 	kube         client.Client
 	log          logging.Logger
 	newServiceFn func(ctx context.Context, creds []byte, kube client.Client) (*kadm.Client, error)

--- a/internal/controller/cluster/topic/topic.go
+++ b/internal/controller/cluster/topic/topic.go
@@ -54,7 +54,7 @@ const (
 
 // A connector is expected to produce an ExternalClient when its Connect method is called.
 type connector struct {
-	cache        kafka.ClientCache
+	cache        *kafka.ClientCache
 	kube         client.Client
 	log          logging.Logger
 	newServiceFn func(ctx context.Context, creds []byte, kube client.Client) (*kadm.Client, error)
@@ -74,6 +74,7 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 
 	opts := []managed.ReconcilerOption{
 		managed.WithExternalConnector(&connector{
+			cache:        &kafka.ClientCache{},
 			kube:         mgr.GetClient(),
 			usage:        resource.NewLegacyProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 			newServiceFn: kafka.NewAdminClient,

--- a/internal/controller/namespaced/acl/acl.go
+++ b/internal/controller/namespaced/acl/acl.go
@@ -60,6 +60,7 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 
 	opts := []managed.ReconcilerOption{
 		managed.WithExternalConnector(&connector{
+			cache:        &kafka.ClientCache{},
 			kube:         mgr.GetClient(),
 			usage:        resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 			newServiceFn: kafka.NewAdminClient,
@@ -113,7 +114,7 @@ func SetupGated(mgr ctrl.Manager, o controller.Options) error {
 
 // A connector is expected to produce an ExternalClient when its Connect method is called.
 type connector struct {
-	cache        kafka.ClientCache
+	cache        *kafka.ClientCache
 	kube         client.Client
 	log          logging.Logger
 	newServiceFn func(ctx context.Context, creds []byte, kube client.Client) (*kadm.Client, error)

--- a/internal/controller/namespaced/topic/topic.go
+++ b/internal/controller/namespaced/topic/topic.go
@@ -55,7 +55,7 @@ const (
 
 // A connector is expected to produce an ExternalClient when its Connect method is called.
 type connector struct {
-	cache        kafka.ClientCache
+	cache        *kafka.ClientCache
 	kube         client.Client
 	log          logging.Logger
 	newServiceFn func(ctx context.Context, creds []byte, kube client.Client) (*kadm.Client, error)
@@ -75,6 +75,7 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 
 	opts := []managed.ReconcilerOption{
 		managed.WithExternalConnector(&connector{
+			cache:        &kafka.ClientCache{},
 			kube:         mgr.GetClient(),
 			usage:        resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 			newServiceFn: kafka.NewAdminClient,


### PR DESCRIPTION
  - Use *ClientCache (pointer) in all 4 controllers so the mutex and
    cached client persist across reconciles instead of being copied as
    a zero-value on each call
  - Guard resp[0] access in ACL List/Create against empty broker responses
    to prevent panics
  - Batch topic config changes into a single AlterTopicConfigs call
    instead of one call per changed key
  - Eliminate redundant Get calls in updatePartitions and updateConfigs
    by passing the already-fetched existing topic as a parameter
  - Remove redundant os.Stat calls in cert path validation (os.ReadFile
    already returns descriptive errors for missing files)
  - Validate that at least one broker address is provided, giving a clear
    error instead of an opaque "no available seeds" at runtime
  - Remove unreachable !ok check in topic.Get (Go map zero-value
    semantics make it dead code)

**Test Plan:**

Signed-off-by: Jesús Fernández <7312236+fernandezcuesta@users.noreply.github.com>
