### PR TITLE
chore: refactor

### DIFF
--- a/internal/clients/kafka/topic/topic.go
+++ b/internal/clients/kafka/topic/topic.go
@@ -37,6 +37,11 @@ const (
 	ErrTopicDoesNotExist = "topic does not exist"
 )
 
+var (
+	// ErrCannotDecreasePartitions indicates that reducing partition count is not supported by Kafka.
+	ErrCannotDecreasePartitions = errors.New("cannot decrease topic partitions")
+)
+
 // Get gets the topic from Kafka side and returns a Topic object.
 func Get(ctx context.Context, client *kadm.Client, name string) (*Topic, error) {
 	td, err := client.ListTopics(ctx, name)
@@ -144,8 +149,8 @@ func Update(ctx context.Context, client *kadm.Client, desired *Topic) error {
 // updatePartitions updates a topic Partition count in Kafka, reusing the already-fetched existing topic.
 func updatePartitions(ctx context.Context, client *kadm.Client, desired *Topic, existing *Topic) error {
 	if desired.Partitions < existing.Partitions {
-		return fmt.Errorf("cannot decrease topic partitions from %d to %d: Kafka does not support reducing the number of partitions",
-			existing.Partitions, desired.Partitions)
+		return fmt.Errorf("%w from %d to %d: Kafka does not support reducing the number of partitions",
+			ErrCannotDecreasePartitions, existing.Partitions, desired.Partitions)
 	}
 	resp, err := client.UpdatePartitions(ctx, int(desired.Partitions), desired.Name)
 	if err != nil {
@@ -207,6 +212,16 @@ func Generate(name string, params *v1alpha1.TopicParameters) *Topic {
 	}
 
 	return tpc
+}
+
+// ToObservation converts a Kafka Topic to a TopicObservation.
+func (t *Topic) ToObservation() v1alpha1.TopicObservation {
+	return v1alpha1.TopicObservation{
+		ID:                t.ID,
+		ReplicationFactor: int(t.ReplicationFactor),
+		Partitions:        int(t.Partitions),
+		Config:            t.Config,
+	}
 }
 
 // IsUpToDate returns true if the supplied Kubernetes resource matches the

--- a/internal/clients/kafka/topic/topic.go
+++ b/internal/clients/kafka/topic/topic.go
@@ -37,10 +37,8 @@ const (
 	ErrTopicDoesNotExist = "topic does not exist"
 )
 
-var (
-	// ErrCannotDecreasePartitions indicates that reducing partition count is not supported by Kafka.
-	ErrCannotDecreasePartitions = errors.New("cannot decrease topic partitions")
-)
+// ErrCannotDecreasePartitions indicates that reducing partition count is not supported by Kafka.
+var ErrCannotDecreasePartitions = errors.New("cannot decrease topic partitions")
 
 // Get gets the topic from Kafka side and returns a Topic object.
 func Get(ctx context.Context, client *kadm.Client, name string) (*Topic, error) {

--- a/internal/clients/kafka/topic/topic_test.go
+++ b/internal/clients/kafka/topic/topic_test.go
@@ -665,36 +665,33 @@ func TestPreExistingTopicUpdateConfig(t *testing.T) {
 }
 
 func TestUpdatePartitions_DecreasePartitionsFails(t *testing.T) {
-	cases := map[string]struct {
-		existingPartitions int32
-		desiredPartitions  int32
-		wantErr            bool
-	}{
-		"DecreasePartitionsFails": {
-			existingPartitions: 5,
-			desiredPartitions:  3,
-			wantErr:            true,
-		},
-		"IncreasePartitionsAllowed": {
-			existingPartitions: 3,
-			desiredPartitions:  5,
-			wantErr:            false,
-		},
-		"SamePartitionsAllowed": {
-			existingPartitions: 4,
-			desiredPartitions:  4,
-			wantErr:            false,
+	t.Parallel()
+
+	err := updatePartitions(context.Background(), nil, &Topic{Partitions: 3}, &Topic{Partitions: 5})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCannotDecreasePartitions)
+	assert.Contains(t, err.Error(), "from 5 to 3")
+}
+
+func TestToObservation(t *testing.T) {
+	t.Parallel()
+
+	strPtr := func(s string) *string { return &s }
+
+	tpc := &Topic{
+		ID:                "abc-123",
+		ReplicationFactor: 3,
+		Partitions:        12,
+		Config: map[string]*string{
+			configKeyRetentionMs: strPtr("86400000"),
+			"cleanup.policy":     strPtr("delete"),
 		},
 	}
 
-	for name, tt := range cases {
-		t.Run(name, func(t *testing.T) {
-			// Validate the partition decrease check logic
-			shouldError := tt.desiredPartitions < tt.existingPartitions
-			if shouldError != tt.wantErr {
-				t.Errorf("partition decrease validation failed: desired=%d, existing=%d, wantErr=%v, got=%v",
-					tt.desiredPartitions, tt.existingPartitions, tt.wantErr, shouldError)
-			}
-		})
-	}
+	got := tpc.ToObservation()
+
+	assert.Equal(t, tpc.ID, got.ID)
+	assert.Equal(t, int(tpc.ReplicationFactor), got.ReplicationFactor)
+	assert.Equal(t, int(tpc.Partitions), got.Partitions)
+	assert.Equal(t, tpc.Config, got.Config)
 }

--- a/internal/clients/kafka/topic/topic_test.go
+++ b/internal/clients/kafka/topic/topic_test.go
@@ -669,7 +669,7 @@ func TestUpdatePartitions_DecreasePartitionsFails(t *testing.T) {
 
 	err := updatePartitions(context.Background(), nil, &Topic{Partitions: 3}, &Topic{Partitions: 5})
 	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrCannotDecreasePartitions)
+	require.ErrorIs(t, err, ErrCannotDecreasePartitions)
 	assert.Contains(t, err.Error(), "from 5 to 3")
 }
 

--- a/internal/controller/cluster/topic/topic.go
+++ b/internal/controller/cluster/topic/topic.go
@@ -189,10 +189,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	// AddFinalizer and re-populates status there.
 	statusPopulated := cr.Status.AtProvider.ID != ""
 
-	cr.Status.AtProvider.ID = tpc.ID
-	cr.Status.AtProvider.ReplicationFactor = int(tpc.ReplicationFactor)
-	cr.Status.AtProvider.Partitions = int(tpc.Partitions)
-	cr.Status.AtProvider.Config = tpc.Config
+	cr.Status.AtProvider = tpc.ToObservation()
 	cr.Status.SetConditions(xpv2.Available())
 
 	return managed.ExternalObservation{
@@ -225,18 +222,15 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalUpdate{}, err
 	}
 
-	// Re-populate status which may have been reset by AddFinalizer's
-	// full-object Update on the first reconcile.
-	tpc, err := topic.Get(ctx, c.kafkaClient, name)
-	if err != nil {
-		return managed.ExternalUpdate{}, fmt.Errorf(errGetTopic+": %w", err)
-	}
+	if cr.Status.AtProvider.ID == "" {
+		tpc, err := topic.Get(ctx, c.kafkaClient, name)
+		if err != nil {
+			return managed.ExternalUpdate{}, fmt.Errorf(errGetTopic+": %w", err)
+		}
 
-	cr.Status.AtProvider.ID = tpc.ID
-	cr.Status.AtProvider.ReplicationFactor = int(tpc.ReplicationFactor)
-	cr.Status.AtProvider.Partitions = int(tpc.Partitions)
-	cr.Status.AtProvider.Config = tpc.Config
-	cr.Status.SetConditions(xpv2.Available())
+		cr.Status.AtProvider = tpc.ToObservation()
+		cr.Status.SetConditions(xpv2.Available())
+	}
 
 	return managed.ExternalUpdate{}, nil
 }

--- a/internal/controller/cluster/topic/topic_test.go
+++ b/internal/controller/cluster/topic/topic_test.go
@@ -186,10 +186,7 @@ func TestPopulateTopicAtProvider(t *testing.T) {
 			cr := &v1alpha1.Topic{}
 			cr.Status.SetConditions(xpv2.Available())
 
-			cr.Status.AtProvider.ID = tc.observed.ID
-			cr.Status.AtProvider.ReplicationFactor = int(tc.observed.ReplicationFactor)
-			cr.Status.AtProvider.Partitions = int(tc.observed.Partitions)
-			cr.Status.AtProvider.Config = tc.observed.Config
+			cr.Status.AtProvider = tc.observed.ToObservation()
 
 			if diff := cmp.Diff(tc.want, cr.Status.AtProvider); diff != "" {
 				t.Errorf("\n%s\natProvider: -want, +got:\n%s", tc.reason, diff)

--- a/internal/controller/namespaced/topic/topic.go
+++ b/internal/controller/namespaced/topic/topic.go
@@ -204,10 +204,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	// AddFinalizer and re-populates status there.
 	statusPopulated := cr.Status.AtProvider.ID != ""
 
-	cr.Status.AtProvider.ID = tpc.ID
-	cr.Status.AtProvider.ReplicationFactor = int(tpc.ReplicationFactor)
-	cr.Status.AtProvider.Partitions = int(tpc.Partitions)
-	cr.Status.AtProvider.Config = tpc.Config
+	cr.Status.AtProvider = tpc.ToObservation()
 	cr.Status.SetConditions(xpv2.Available())
 
 	return managed.ExternalObservation{
@@ -240,18 +237,15 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalUpdate{}, err
 	}
 
-	// Re-populate status which may have been reset by AddFinalizer's
-	// full-object Update on the first reconcile.
-	tpc, err := topic.Get(ctx, c.kafkaClient, name)
-	if err != nil {
-		return managed.ExternalUpdate{}, fmt.Errorf(errGetTopic+": %w", err)
-	}
+	if cr.Status.AtProvider.ID == "" {
+		tpc, err := topic.Get(ctx, c.kafkaClient, name)
+		if err != nil {
+			return managed.ExternalUpdate{}, fmt.Errorf(errGetTopic+": %w", err)
+		}
 
-	cr.Status.AtProvider.ID = tpc.ID
-	cr.Status.AtProvider.ReplicationFactor = int(tpc.ReplicationFactor)
-	cr.Status.AtProvider.Partitions = int(tpc.Partitions)
-	cr.Status.AtProvider.Config = tpc.Config
-	cr.Status.SetConditions(xpv2.Available())
+		cr.Status.AtProvider = tpc.ToObservation()
+		cr.Status.SetConditions(xpv2.Available())
+	}
 
 	return managed.ExternalUpdate{}, nil
 }

--- a/internal/controller/namespaced/topic/topic_test.go
+++ b/internal/controller/namespaced/topic/topic_test.go
@@ -181,10 +181,7 @@ func TestPopulateTopicAtProvider(t *testing.T) {
 			cr := &v1alpha1.Topic{}
 			cr.Status.SetConditions(xpv2.Available())
 
-			cr.Status.AtProvider.ID = tc.observed.ID
-			cr.Status.AtProvider.ReplicationFactor = int(tc.observed.ReplicationFactor)
-			cr.Status.AtProvider.Partitions = int(tc.observed.Partitions)
-			cr.Status.AtProvider.Config = tc.observed.Config
+			cr.Status.AtProvider = tc.observed.ToObservation()
 
 			if diff := cmp.Diff(tc.want, cr.Status.AtProvider); diff != "" {
 				t.Errorf("\n%s\natProvider: -want, +got:\n%s", tc.reason, diff)


### PR DESCRIPTION
- Extract `Topic.ToObservation()` to centralize status mapping from Kafka topic to TopicObservation, replacing 4 duplicate field-copy blocks across cluster and namespaced controllers
- Guard status re-population in `Update()` to avoid unnecessary `topic.Get()` calls on every update, only fetches when status was reset by` AddFinalizer` on first reconcile.
- Replace weak partition-decrease test (validated logic inline without calling real code) with test that calls updatePartitions directly and asserts error.
- Add `TestToObservation` unit test